### PR TITLE
feat(api): add admin-only generate_election_result endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,6 +1909,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "color-eyre",
+ "csv",
  "curve25519-dalek",
  "dashmap 6.1.0",
  "derive_builder",
@@ -2277,6 +2278,27 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa 1.0.15",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/crates/common_core/Cargo.toml
+++ b/crates/common_core/Cargo.toml
@@ -44,6 +44,7 @@ base64 = "0.22.1"
 qrcode = "0.14.1"
 image = "0.25.6"
 unic-langid = { version = "0.9.5", features = ["unic-langid-macros"] }
+csv = "1.3.1"
 
 [features]
 default = [ "scalar", "diesel" ]

--- a/crates/common_core/src/prelude/mod.rs
+++ b/crates/common_core/src/prelude/mod.rs
@@ -14,10 +14,28 @@ pub use color_eyre::Result as CResult;
 
 pub use bs58;
 
+cfg_if!{
+    if #[cfg(target_arch = "wasm32")] {
+    } else {
+        pub use std::{
+            fs::{
+                self,
+                File,
+            },
+            io::{
+                self,
+                Write,
+            },
+        };
+    }
+}
+pub use csv::{
+    self,
+    WriterBuilder,
+};
 pub use std::fmt::Display;
 pub use std::fmt::Debug;
 pub use std::{
-    io,
     sync::atomic::{
         AtomicBool,
         Ordering,

--- a/crates/election_shared/src/models/vote_record.rs
+++ b/crates/election_shared/src/models/vote_record.rs
@@ -16,7 +16,7 @@ use crate::schema::{
 pub struct VoteRecord {
     pub id: i32,
     pub vote_choice: String,
-    // #[serde(with = "serde_json")]
+    #[serde(with = "base58")]
     pub ring_sig: Vec<u8>,
 }
 
@@ -59,7 +59,7 @@ impl VoteRecord {
 pub struct NewVoteRecord {
     #[builder(setter(into))]
     pub vote_choice: String,
-    // #[serde(with = "serde_json")]
+    #[serde(with = "base58")]
     #[builder(default = "Vec::new()")]
     pub ring_sig: Vec<u8>,
 }

--- a/crates/veri_anon_vote_server/src/main.rs
+++ b/crates/veri_anon_vote_server/src/main.rs
@@ -92,6 +92,7 @@ impl ServerContext {
                     .service(toggle_registration_status)
                     .service(get_all_verifiers_details)
                     .service(toggle_election_status)
+                    .service(generate_election_result)
                 )
                 .service(SwaggerUi::new("/swagger-ui/admin/{_:.*}").urls(vec![
                         (

--- a/crates/veri_anon_vote_server/src/prelude.rs
+++ b/crates/veri_anon_vote_server/src/prelude.rs
@@ -48,6 +48,7 @@ pub use election_organizer::handlers::{
     admin::{
         // self,
         toggle_election_status,
+        generate_election_result,
     },
     public::{
         insert_vote_record,


### PR DESCRIPTION
### Description
This PR introduces a new API endpoint `generate_election_result` that requires admin API key authentication. The endpoint fetches all voter records from the database, generates a CSV file, and stores it in the `public/files` directory relative to the sqlite3 path.

### Motivation
The purpose of this feature is to allow administrators to export election results as a CSV file for further audit and reporting.

### Changes
- Added `generate_election_result` API endpoint with admin API key authentication.
- Implemented logic to query voter records from the database.
- Generated CSV file and stored it in `public/files` directory.

### Testing
- [x] Tested the endpoint with a valid admin API key to ensure authentication works.
- [x] Verified that voter data is correctly fetched and CSV is generated.
- [x] Confirmed the CSV file is saved in the correct directory.